### PR TITLE
docs: update README with Arbitrum contract status

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ cargo near deploy build-non-reproducible-wasm
 - IDE: Zed
 - Chains: Arbitrum Stylus, Solana, NEAR
 
-## Getting Started
+## Arbitrum
 
-_Will be populated as we progress._
+"Counter contract written and tested locally.


### PR DESCRIPTION
Update README to reflect Arbitrum Counter contract status — written and tested locally, deployment skipped due to testnet faucet unavailability